### PR TITLE
링크를 통한 채팅방 접속 구현 후 배포

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import AuthRedirectPage from './pages/AuthRedirectPage';
+import AuthRedirectPage from './pages/redirect/AuthRedirectPage';
 import SignupGatePage from './pages/signup/SignupGatePage';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AuthProvider } from './context/AuthContext';

--- a/src/api/services/shopLinkService.js
+++ b/src/api/services/shopLinkService.js
@@ -1,0 +1,30 @@
+import axiosClient from '../axiosClient';
+
+export const shopLinkService = {
+  /**
+   * 매장 링크 조회 (점주용)
+   * 항상 user라는 이름으로 빈 객체를 파라미터에 포함
+   * @returns {Promise<Object>} fullUrl, canonicalUrl, slug, publicCode
+   */
+  getShopLink: async () => {
+    const res = await axiosClient.get('/shop/link', {
+      params: {
+        user: {},
+      },
+    });
+    return res.data;
+  },
+
+  /**
+   * 공개 링크로 채팅방 조회 or 생성
+   * @param {string} slugOrCode - 매장 식별 코드
+   */
+  getChatRoomByCode: async (slugOrCode) => {
+    const res = await axiosClient.get(`/link/chat/${slugOrCode}`, {
+      params: {
+        user: {},
+      },
+    });
+    return res.data;
+  },
+};

--- a/src/components/auth/SignupButton.jsx
+++ b/src/components/auth/SignupButton.jsx
@@ -6,6 +6,7 @@ import theme from '../../styles/theme';
 export const SignupButton = {
   Customer: styled(BaseButton).attrs({
     className: 'w-[143px] font-semibold',
+    $width: '143px',
     $height: '55px',
     $fontSize: '19px',
   })`
@@ -23,6 +24,7 @@ export const SignupButton = {
 
   Owner: styled(BaseButton).attrs({
     className: 'w-[143px] font-semibold',
+    $width: '143px',
     $height: '55px',
     $fontSize: '19px',
   })`

--- a/src/components/common/NextButton.jsx
+++ b/src/components/common/NextButton.jsx
@@ -5,6 +5,7 @@ import theme from '../../styles/theme';
 
 export const NextButton = styled(BaseButton).attrs({
   className: 'w-[100%]',
+  $width: '305px',
   $height: '55px',
   $fontSize: '18px',
 })`

--- a/src/pages/redirect/AuthRedirectPage.jsx
+++ b/src/pages/redirect/AuthRedirectPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useHandleAuthCode } from '../query/authQueries';
+import { useHandleAuthCode } from '../../query/authQueries';
 
 function AuthRedirectPage() {
   const [searchParams] = useSearchParams();

--- a/src/pages/redirect/LinkRedirectPage.jsx
+++ b/src/pages/redirect/LinkRedirectPage.jsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import Container from '../../components/common/Container';
+import { authStorage } from '../../utils/auth/authStorage';
+import { useLinkChat } from '../../query/linkQueries';
+export default function LinkRedirectPage() {
+  const { slugOrCode } = useParams(); //가게 식별 코드
+  const navigate = useNavigate();
+  const location = useLocation();
+  const accessToken = authStorage.getAccessToken();
+
+  // 1. 로그인 여부 확인
+  useEffect(() => {
+    if (!accessToken) {
+      // 비회원이면 회원가입 페이지로 이동 + redirect 유지
+      navigate(`/signup?redirect=${location.pathname}`, { replace: true });
+    }
+  }, [navigate, location.pathname]);
+
+  // 2️. 로그인된 상태라면 채팅방 조회 or 생성
+  const { data, isLoading, isError } = useLinkChat(slugOrCode);
+
+  useEffect(() => {
+    if (data) {
+      const { roomId, shopId, isNewRoom } = data;
+      //해당 채팅방 이동
+      navigate(`/chat/${roomId}`, {
+        state: { shopId, isNewRoom },
+        replace: true, //브라우저 히스토리 덮어쓰기
+      });
+    }
+  }, [data, navigate]);
+
+  // 에러 시 홈으로 리다이렉트
+  useEffect(() => {
+    if (isError) {
+      alert('잘못된 링크이거나 만료된 링크입니다.');
+      navigate('/');
+    }
+  }, [isError, navigate]);
+
+  if (isLoading) {
+    return <Container>연결 중입니다...</Container>;
+  }
+
+  return null;
+}

--- a/src/pages/signup/SignupGatePage.jsx
+++ b/src/pages/signup/SignupGatePage.jsx
@@ -11,12 +11,23 @@ function SignupGatePage() {
   const [selectedRole, setSelectedRole] = useState(null); //회원 유형
   const navigate = useNavigate();
   const location = useLocation();
+
   const isSignupRequired = location.state?.isSignupRequired;
+  const redirect = new URLSearchParams(location.search).get('redirect');
 
   const handleNext = () => {
     if (!selectedRole) return alert('회원 유형을 선택해주세요');
+
+    // redirect 값이 있을 땐 고객만 허용
+    if (redirect && selectedRole !== 'customer') {
+      return alert('링크를 통한 회원가입은 고객만 가능합니다.');
+    }
+
     //회원 분기에 따라 분기
-    navigate(`/signup/${selectedRole}`, { state: { isSignupRequired: true } });
+    //redirect 값을 다음 페이지로 그대로 전달
+    navigate(`/signup/${selectedRole}?redirect=${redirect || ''}`, {
+      state: { isSignupRequired: true },
+    });
   };
 
   useEffect(() => {

--- a/src/query/linkQueries.js
+++ b/src/query/linkQueries.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { shopLinkService } from '../api/services/shopLinkService';
+
+//매장 링크 조회 (점주용)
+export const useShopLink = () => {
+  return useQuery({
+    queryKey: ['shopLink'],
+    queryFn: () => shopLinkService.getShopLink(),
+  });
+};
+
+//식별 코드를 통한  채팅방 생성 or 조회
+export const useLinkChat = (slugOrCode) => {
+  return useQuery({
+    queryKey: ['linkChat', slugOrCode],
+    queryFn: () => shopLinkService.getChatRoomByCode(slugOrCode),
+    enabled: !!slugOrCode,
+  });
+};


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 링크 접속을 통한 해당 점주, 고객 채팅방 이동 구현
<!-- 어떤 작업을 했는지 간략히 설명 -->


---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 링크를 통해 백앤드가 프런트로 리다이렉트시 식별코드를 통해 비회원일시 회원가입 후 채팅방 이동, 이미 회원일시 바로 채팅방이동, 기존 채팅방 존재시 채팅방 이동을 구현

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #48 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-아직 메시지가 하나도 없을때 계속 반복적으로 get메소드를 호출헤서 메시지를 불러오는 오류는 추후에 수정할 계획, 메시지 전송 ,조회 문제는 없음, 채팅방에서 나갔을때 라우팅관련 문제 또한 추후 수정 계획
