### PR TITLE
링크를 통한 채팅 접속 오류 수정 후 배포

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+dev-dist

--- a/src/api/services/kakaoAuthService.js
+++ b/src/api/services/kakaoAuthService.js
@@ -4,8 +4,16 @@ import axiosClient from '../axiosClient';
 
 export const kakaoAuthService = {
   //카카오 로그인 URL 제공
-  getAuthUrl: () =>
-    `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`,
+  getAuthUrl: (redirect) => {
+    // redirect 파라미터가 있을 경우 쿼리 형태로 추가
+    const redirectParam = redirect ? `?redirect=${encodeURIComponent(redirect)}` : '';
+    return (
+      `https://kauth.kakao.com/oauth/authorize` +
+      `?response_type=code` +
+      `&client_id=${REST_API_KEY}` +
+      `&redirect_uri=${REDIRECT_URI}${redirectParam}`
+    );
+  },
 
   // 인가 코드 교환 (로컬/배포 자동 선택)
   exchangeCodeForToken: async (code) => {

--- a/src/components/auth/KakaoLoginButton.jsx
+++ b/src/components/auth/KakaoLoginButton.jsx
@@ -22,10 +22,11 @@ const KakaoButton = styled(BaseButton).attrs({
   }
 `;
 
-function KakaoLoginButton() {
+function KakaoLoginButton({ redirect }) {
   //카카오 로그인 URL변경
   const handleLogin = () => {
-    window.location.href = kakaoAuthService.getAuthUrl();
+    // redirect가 있으면 카카오 인가 URL 뒤에 붙여 전달
+    window.location.href = kakaoAuthService.getAuthUrl(redirect);
   };
 
   return (

--- a/src/pages/home/HomePage.jsx
+++ b/src/pages/home/HomePage.jsx
@@ -9,6 +9,8 @@ import Container from '../../components/common/Container';
 import Header from '../../components/common/Header';
 import MainActionButton from '../../components/home/MainActionButton ';
 import BottomNav from '../../components/common/BottomNav';
+import { BaseButton } from '../../components/common/Button';
+import { NextButton } from '../../components/common/NextButton';
 
 export default function HomePage() {
   const navigate = useNavigate();
@@ -40,6 +42,10 @@ export default function HomePage() {
           <MainActionButton onClick={goToChat} icon={ChatIcon} label="채팅방 조회" />
           <MainActionButton onClick={goToReservationList} icon={BookIcon} label="예약 내역" />
         </S.ButtonGroup>
+        {/* 임시 회원탈퇴 버튼 */}
+        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 w-[90%] flex justify-center">
+          <NextButton onClick={deleteUserHandler}>임시 회원 탈퇴</NextButton>
+        </div>
         <BottomNav />
       </S.CenterArea>
     </Container>

--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import Container from '../../components/common/Container';
+import { useLocation } from 'react-router-dom';
 import KakaoLoginButton from '../../components/auth/KakaoLoginButton';
 import logoImg from '../../assets/icons/logo-icon.svg';
 
 export default function LoginPage() {
+  const location = useLocation();
+  const redirect = new URLSearchParams(location.search).get('redirect'); //링크 접속시 매장 식별코드
   return (
     <Container>
       <div className="flex flex-col">
@@ -13,7 +16,7 @@ export default function LoginPage() {
           {/* 타이틀 */}
           <h1>SNAPBOOK</h1>
         </div>
-        <KakaoLoginButton />
+        <KakaoLoginButton redirect={redirect} /> {/*식별코드 전달*/}
       </div>
     </Container>
   );

--- a/src/pages/redirect/LinkRedirectPage.jsx
+++ b/src/pages/redirect/LinkRedirectPage.jsx
@@ -1,24 +1,26 @@
 import { useEffect } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import Container from '../../components/common/Container';
 import { authStorage } from '../../utils/auth/authStorage';
 import { useLinkChat } from '../../query/linkQueries';
+
 export default function LinkRedirectPage() {
   const { slugOrCode } = useParams(); //가게 식별 코드
   const navigate = useNavigate();
-  const location = useLocation();
   const accessToken = authStorage.getAccessToken();
 
   // 1. 로그인 여부 확인
   useEffect(() => {
     if (!accessToken) {
       // 비회원이면 회원가입 페이지로 이동 + redirect 유지
-      navigate(`/signup?redirect=${location.pathname}`, { replace: true });
+      navigate(`/?redirect=${slugOrCode}`, { replace: true });
     }
-  }, [navigate, location.pathname]);
+  }, [navigate]);
 
   // 2️. 로그인된 상태라면 채팅방 조회 or 생성
-  const { data, isLoading, isError } = useLinkChat(slugOrCode);
+  const { data, isLoading, isError } = useLinkChat(slugOrCode, {
+    enabled: !!accessToken,
+  });
 
   useEffect(() => {
     if (data) {

--- a/src/pages/signup/SignupGatePage.jsx
+++ b/src/pages/signup/SignupGatePage.jsx
@@ -14,10 +14,8 @@ function SignupGatePage() {
 
   const isSignupRequired = location.state?.isSignupRequired;
   const redirect = new URLSearchParams(location.search).get('redirect');
-
   const handleNext = () => {
     if (!selectedRole) return alert('회원 유형을 선택해주세요');
-
     // redirect 값이 있을 땐 고객만 허용
     if (redirect && selectedRole !== 'customer') {
       return alert('링크를 통한 회원가입은 고객만 가능합니다.');

--- a/src/pages/signup/SignupPage.jsx
+++ b/src/pages/signup/SignupPage.jsx
@@ -61,7 +61,8 @@ function SignupPage({ userType }) {
       onSuccess: () => {
         // 회원가입 성공 시 redirect로 복귀
         if (redirect) {
-          navigate(redirect, { replace: true });
+          //식별코드 관련 리다이렉트 페이지로 다시 이동
+          navigate(`/s/${redirect}`, { replace: true });
         } else {
           navigate('/'); // 기본 홈으로
         }

--- a/src/query/authQueries.js
+++ b/src/query/authQueries.js
@@ -1,13 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
 import { kakaoAuthService } from '../api/services/kakaoAuthService';
 import { authStorage } from '../utils/auth/authStorage';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export const useHandleAuthCode = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
+  //링크 접속 시 식별코드 읽기
+  const redirect = new URLSearchParams(location.search).get('redirect');
   return useMutation({
     mutationFn: (code) => kakaoAuthService.exchangeCodeForToken(code),
     onSuccess: (data) => {
@@ -16,8 +19,8 @@ export const useHandleAuthCode = () => {
 
       //회언가입 분기처리
       if (data.authStatus === 'SIGNUP_REQUIRED') {
-        //신규 유저 -> 가입 선택 화면으로
-        navigate('/signup', { state: { isSignupRequired: true } });
+        //신규 유저 -> 가입 선택 화면으로(링크 접속 사용자는 식별코드 가지고)
+        navigate(`/signup?redirect=${redirect || ''}`, { state: { isSignupRequired: true } });
       } else {
         // 로그인 성공
         navigate('/');

--- a/src/query/linkQueries.js
+++ b/src/query/linkQueries.js
@@ -10,10 +10,10 @@ export const useShopLink = () => {
 };
 
 //식별 코드를 통한  채팅방 생성 or 조회
-export const useLinkChat = (slugOrCode) => {
+export const useLinkChat = (slugOrCode, options = {}) => {
   return useQuery({
     queryKey: ['linkChat', slugOrCode],
     queryFn: () => shopLinkService.getChatRoomByCode(slugOrCode),
-    enabled: !!slugOrCode,
+    enabled: !!slugOrCode && (options.enabled ?? true),
   });
 };


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 링크를 통한 채팅 접속 오류 수정

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 먼저 비회원이 링크를 타고 프런트로 접속할 경우 회원가입까지는 가능하지만 회원가입 후 채팅방 진입이 되지 못한 문제를 카카오 인가서버 관련 url의 쿼리파라미터에 식별 코드를 추가하는 방법으로 계속 식별코드를 가지고 있게 하는 함으로 회원가입 후 채팅방 이동을 할 수 있게 수정했다.

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #53 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
아직 이미 회원인 사용자가 링크를 타고 접속했을떄 처리하는 로직이 확실하지 못한 것 같으므로 추후 수정 계획
첫 채팅방 접속시 불필요하게 연속적으로 api를 호출해서 추후 제어할 계획
첫 채팅방 접속시 메시지 조회가 403이 뜨지만 새로고침시 제대로 동작하는 문제가 있음
