### PR TITLE
링크를 통한 채팅 접속 오류 수정 및 구조개선 후 배

### DIFF
--- a/src/api/services/kakaoAuthService.js
+++ b/src/api/services/kakaoAuthService.js
@@ -4,9 +4,9 @@ import axiosClient from '../axiosClient';
 
 export const kakaoAuthService = {
   //카카오 로그인 URL 제공
-  getAuthUrl: (redirect) => {
-    // redirect 파라미터가 있을 경우 쿼리 형태로 추가
-    const redirectParam = redirect ? `?redirect=${encodeURIComponent(redirect)}` : '';
+  getAuthUrl: (slug) => {
+    // 매장 식별 코드가 있을 경우 경로에 추가
+    const redirectParam = slug ? `&state=${encodeURIComponent(slug)}` : '';
     return (
       `https://kauth.kakao.com/oauth/authorize` +
       `?response_type=code` +

--- a/src/components/auth/KakaoLoginButton.jsx
+++ b/src/components/auth/KakaoLoginButton.jsx
@@ -22,11 +22,11 @@ const KakaoButton = styled(BaseButton).attrs({
   }
 `;
 
-function KakaoLoginButton({ redirect }) {
+function KakaoLoginButton({ slug }) {
   //카카오 로그인 URL변경
   const handleLogin = () => {
-    // redirect가 있으면 카카오 인가 URL 뒤에 붙여 전달
-    window.location.href = kakaoAuthService.getAuthUrl(redirect);
+    // slug(매장 식별코드) 있으면 카카오 인가 URL 뒤에 붙여 전달
+    window.location.href = kakaoAuthService.getAuthUrl(slug);
   };
 
   return (

--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -6,7 +6,7 @@ import logoImg from '../../assets/icons/logo-icon.svg';
 
 export default function LoginPage() {
   const location = useLocation();
-  const redirect = new URLSearchParams(location.search).get('redirect'); //링크 접속시 매장 식별코드
+  const slug = new URLSearchParams(location.search).get('slug'); //링크 접속시 매장 식별코드
   return (
     <Container>
       <div className="flex flex-col">
@@ -16,7 +16,7 @@ export default function LoginPage() {
           {/* 타이틀 */}
           <h1>SNAPBOOK</h1>
         </div>
-        <KakaoLoginButton redirect={redirect} /> {/*식별코드 전달*/}
+        <KakaoLoginButton slug={slug} /> {/*식별코드 전달*/}
       </div>
     </Container>
   );

--- a/src/pages/redirect/LinkRedirectPage.jsx
+++ b/src/pages/redirect/LinkRedirectPage.jsx
@@ -12,8 +12,8 @@ export default function LinkRedirectPage() {
   // 1. 로그인 여부 확인
   useEffect(() => {
     if (!accessToken) {
-      // 비회원이면 회원가입 페이지로 이동 + redirect 유지
-      navigate(`/?redirect=${slugOrCode}`, { replace: true });
+      // 비회원이면 회원가입 페이지로 이동 + slug(매장식별코드) 유지
+      navigate(`/?slug=${slugOrCode}`, { replace: true });
     }
   }, [navigate]);
 

--- a/src/pages/signup/SignupGatePage.jsx
+++ b/src/pages/signup/SignupGatePage.jsx
@@ -13,17 +13,17 @@ function SignupGatePage() {
   const location = useLocation();
 
   const isSignupRequired = location.state?.isSignupRequired;
-  const redirect = new URLSearchParams(location.search).get('redirect');
+  const slug = new URLSearchParams(location.search).get('slug');
   const handleNext = () => {
     if (!selectedRole) return alert('회원 유형을 선택해주세요');
-    // redirect 값이 있을 땐 고객만 허용
-    if (redirect && selectedRole !== 'customer') {
+    // slug 값이 있을 땐 고객만 허용
+    if (slug && selectedRole !== 'customer') {
       return alert('링크를 통한 회원가입은 고객만 가능합니다.');
     }
 
     //회원 분기에 따라 분기
-    //redirect 값을 다음 페이지로 그대로 전달
-    navigate(`/signup/${selectedRole}?redirect=${redirect || ''}`, {
+    //slug 값을 다음 페이지로 그대로 전달
+    navigate(`/signup/${selectedRole}?slug=${slug || ''}`, {
       state: { isSignupRequired: true },
     });
   };

--- a/src/pages/signup/SignupPage.jsx
+++ b/src/pages/signup/SignupPage.jsx
@@ -11,11 +11,11 @@ function SignupPage({ userType }) {
   const location = useLocation();
   const isSignupRequired = location.state?.isSignupRequired;
 
-  // redirect 쿼리값 추출
-  const redirect = new URLSearchParams(location.search).get('redirect');
+  // slug 쿼리값 추출
+  const slug = new URLSearchParams(location.search).get('slug');
 
-  // redirect 있으면 무조건 CUSTOMER 로 고정 없다면 그대로 진행
-  const effectiveUserType = redirect ? 'CUSTOMER' : userType;
+  // slug 있으면 무조건 CUSTOMER 로 고정 없다면 그대로 진행
+  const effectiveUserType = slug ? 'CUSTOMER' : userType;
 
   // 타입별 고객, 점주 회원가입 훅 선택
   const signup = effectiveUserType === 'CUSTOMER' ? useSignupCustomer() : useSignupOwner();
@@ -50,24 +50,15 @@ function SignupPage({ userType }) {
       return;
     }
 
-    // redirect 존재 + 점주 회원가입 시도 방지
-    if (redirect && userType !== 'CUSTOMER') {
+    // slug 존재 + 점주 회원가입 시도 방지
+    if (slug && userType !== 'CUSTOMER') {
       alert('링크를 통한 회원가입은 고객만 가능합니다.');
       navigate('/'); // 홈으로 이동
       return;
     }
 
-    signup.mutate(formData, {
-      onSuccess: () => {
-        // 회원가입 성공 시 redirect로 복귀
-        if (redirect) {
-          //식별코드 관련 리다이렉트 페이지로 다시 이동
-          navigate(`/s/${redirect}`, { replace: true });
-        } else {
-          navigate('/'); // 기본 홈으로
-        }
-      },
-    });
+    //회원가입 폼 전달
+    signup.mutate(formData);
   };
 
   return (

--- a/src/query/authQueries.js
+++ b/src/query/authQueries.js
@@ -10,7 +10,7 @@ export const useHandleAuthCode = () => {
   const location = useLocation();
 
   //링크 접속 시 식별코드 읽기
-  const redirect = new URLSearchParams(location.search).get('redirect');
+  const slug = new URLSearchParams(location.search).get('state');
   return useMutation({
     mutationFn: (code) => kakaoAuthService.exchangeCodeForToken(code),
     onSuccess: (data) => {
@@ -20,10 +20,15 @@ export const useHandleAuthCode = () => {
       //회언가입 분기처리
       if (data.authStatus === 'SIGNUP_REQUIRED') {
         //신규 유저 -> 가입 선택 화면으로(링크 접속 사용자는 식별코드 가지고)
-        navigate(`/signup?redirect=${redirect || ''}`, { state: { isSignupRequired: true } });
+        navigate(`/signup?slug=${slug || ''}`, { state: { isSignupRequired: true } });
       } else {
-        // 로그인 성공
-        navigate('/');
+        //식별 코드 있다면 바로 채팅방 리다이렉트용 임시페이지 이동
+        if (slug) {
+          navigate(`/s/${slug}`, { replace: true });
+        } else {
+          // 일반 로그인시 홈으로
+          navigate('/');
+        }
       }
     },
     onError: (error) => {

--- a/src/query/signupQueries.js
+++ b/src/query/signupQueries.js
@@ -5,7 +5,11 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 export const useSignupCustomer = () => {
   const { login } = useAuth();
-  const naviagate = useNavigate();
+  const navigate = useNavigate();
+
+  // 매장 식별 코드
+  const slug = new URLSearchParams(location.search).get('slug');
+
   return useMutation({
     mutationFn: (payload) => signupService.signupCustomer(payload),
     onSuccess: (data) => {
@@ -15,8 +19,12 @@ export const useSignupCustomer = () => {
       //사용자 정보 전역 상태 + 스토리지 저장
       login(data);
 
-      //마지막으로 홈화면 이동
-      naviagate('/');
+      // slug가 있으면 매장 채팅방 페이지로 이동
+      if (slug) {
+        navigate(`/s/${slug}`, { replace: true });
+      } else {
+        navigate('/'); // 기본 홈
+      }
     },
   });
 };


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 기존 회원이 링크를 통한 접속시 홈으로 가는 문제를 해결

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 일단 식별코드관련 변수명을 더 정확하게 slug로 변경하고 관련 url의 쿼리의 키값을 slug로 변경
- 카카인가서버 관련 url에 slug 관련 쿼리 파라미터의 키값을 state로 변경
- 로그인 분기를 더 명확하게 해서 slug값을 가진 사용자는 채팅방 리다이렉트 페이지로 이동
- 일반 로그인 회원은 홈화면으로 이동 

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
-  #53 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
- 아직 비회원이  처음 채팅방을 만들고 채팅방내 메시지 조회 api가 불필요하게 연속적으로 호출되는 문제는 해결하지 못했으며 추후 수정 계획
