### PR TITLE
fix: 브라우저 히스토리를 이용한 채팅방 내 뒤로가기 문제 해결

### DIFF
--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -28,6 +28,14 @@ export default function ChatRoomPage() {
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
+  const handleBack = () => {
+    if (window.history.state && window.history.state.idx > 0) {
+      navigate(-1); // 이전 페이지가 존재할 경우 채팅 목록 이동
+    } else {
+      navigate('/'); // 외부 유입이라 이전 기록 없을 때 홈으로(링크 유입)
+    }
+  };
+
   const { auth } = useAuth();
   const userId = auth?.userId;
 
@@ -155,7 +163,7 @@ export default function ChatRoomPage() {
     <Container $start>
       <S.PageWrapper>
         <S.Header>
-          <S.BackButton onClick={() => navigate(-1)}>
+          <S.BackButton onClick={handleBack}>
             <img src={backIcon} alt="back" />
           </S.BackButton>
           <ChatRoomTitle>채팅방 #{chatRoomId}</ChatRoomTitle>


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 브라우저 히스토리를 이용한 채팅방 내 뒤로가기 문제 해결

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- window.history를 이용해서 브라우저 히스토리 값을 이용해서 링크로 유입된 사용는 홈으로 일반적인 경로로 채팅방으로 들어온 사용자는 이전 화면(채팅방 목록)이동하게 로직 수정했고 따로 뒤로가기 담당 헨들러를 새로 만드는 방향으로 진행

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #58 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
