### PR TITLE
링크 접근시 매장 정보 조회 api 연동 구현

### DIFF
--- a/src/api/services/shopLinkService.js
+++ b/src/api/services/shopLinkService.js
@@ -27,4 +27,14 @@ export const shopLinkService = {
     });
     return res.data;
   },
+
+  /**
+   * 매장 정보 조회 (공개 링크로 접근 시)
+   * @param {string} slugOrCode - 매장 식별 코드
+   * @returns {Promise<{shopId:number, shopName:string}>}
+   */
+  getShopInfoByCode: async (slugOrCode) => {
+    const res = await axiosClient.get(`/shop/${slugOrCode}`);
+    return res.data;
+  },
 };

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSendMessage, useChatMessages } from '../../query/chatQueries';
 import { chatSocketService } from '../../api/services/chatSocketService';
 import DateDivider from '../../components/chat/DateDivider';
@@ -17,11 +17,17 @@ import { useAuth } from '../../context/AuthContext';
 import { usePreserveScrollPosition } from '../../hooks/chat/usePreserveScrollPosition';
 import { useInitScrollToBottom } from '../../hooks/chat/useInitScrollToBottom';
 import { useTopObserver } from '../../hooks/chat/useTopObserver';
+import { useShopInfoByCode } from '../../query/linkQueries';
 
 export default function ChatRoomPage() {
   const [input, setInput] = useState('');
   const [liveMessages, setLiveMessages] = useState([]);
   const [readyToObserve, setReadyToObserve] = useState(false);
+
+  //링크 유입시 가게 정보 조회
+  const [searchParams] = useSearchParams();
+  const slugOrCode = searchParams.get('slug');
+  const { data: shopInfo } = useShopInfoByCode(slugOrCode);
 
   //예약 모달 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -166,7 +172,10 @@ export default function ChatRoomPage() {
           <S.BackButton onClick={handleBack}>
             <img src={backIcon} alt="back" />
           </S.BackButton>
-          <ChatRoomTitle>채팅방 #{chatRoomId}</ChatRoomTitle>
+          {/*현재 링크 유입시만 가게이름 조회 가능*/}
+          <ChatRoomTitle>
+            {shopInfo?.shopName ? shopInfo.shopName : `채팅방 #${chatRoomId}`}
+          </ChatRoomTitle>
           <S.BookButton onClick={openModal}>예약</S.BookButton>
         </S.Header>
         <S.MessageList ref={messageListRef}>
@@ -222,7 +231,7 @@ export default function ChatRoomPage() {
         </S.InputBar>
       </S.PageWrapper>
       {/*예약 모달 */}
-      <ReservationModal isOpen={isModalOpen} onClose={closeModal} shopId={8} />
+      <ReservationModal isOpen={isModalOpen} onClose={closeModal} shopId={shopInfo?.shopId} />
     </Container>
   );
 }

--- a/src/pages/redirect/LinkRedirectPage.jsx
+++ b/src/pages/redirect/LinkRedirectPage.jsx
@@ -26,7 +26,7 @@ export default function LinkRedirectPage() {
     if (data) {
       const { roomId, shopId, isNewRoom } = data;
       //해당 채팅방 이동
-      navigate(`/chat/${roomId}`, {
+      navigate(`/chat/${roomId}?slug=${slugOrCode}`, {
         state: { shopId, isNewRoom },
         replace: true, //브라우저 히스토리 덮어쓰기
       });

--- a/src/query/linkQueries.js
+++ b/src/query/linkQueries.js
@@ -17,3 +17,12 @@ export const useLinkChat = (slugOrCode, options = {}) => {
     enabled: !!slugOrCode && (options.enabled ?? true),
   });
 };
+
+// 매장 정보 조회 (공개 링크 접근 시)
+export const useShopInfoByCode = (slugOrCode) => {
+  return useQuery({
+    queryKey: ['shopInfo', slugOrCode],
+    queryFn: () => shopLinkService.getShopInfoByCode(slugOrCode),
+    enabled: !!slugOrCode,
+  });
+};


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 링크 접근시 매장 정보 조회 api 연동 구현

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 링크로 접속한 사용자는 현재 가게 정보를 조회하는 api가 없어서 현재 채팅방 내 타이틀에 가게이름을 표시하지 못했지만 관련 api가 생겨서 가게이름을 포함한 가게 정보를 가져올 수 있음, 또한 링크를 접속한 사용자만 shopId를 가져올 수 있어서 링크로 유입된 사용자만 예약이 가능하도록 수정했음 

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #64 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-기존 일반 사용자 또한 채팅방내에서 사용할 수 있는 가게정보 조회 api가 생기면 수정할 예정
