### PR TITLE
예약 전송 완료 메시지 연결 후 배포 

### DIFF
--- a/src/assets/icons/check-icon.svg
+++ b/src/assets/icons/check-icon.svg
@@ -1,0 +1,4 @@
+ <svg width="30px" height="30px" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="15" cy="15" r="15" fill="#F08080"/>
+      <path d="M21 11.5L12.75 19.75L9 16" stroke="#FEE9E7" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>

--- a/src/components/message/ReservationCompleteMessage.jsx
+++ b/src/components/message/ReservationCompleteMessage.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import CheckIcon from '../../assets/icons/check-icon.svg';
+
+export function ReservationCompleteMessage({ name, date, time, photoCount }) {
+  return (
+    <div
+      style={{
+        background: '#fff',
+        border: '4px solid #ededed',
+        borderRadius: 16,
+        width: '225px',
+        height: '206px',
+        padding: '15px',
+        boxShadow: '0 2px 8px #eee',
+        position: 'relative',
+        fontFamily: 'Pretendard',
+        color: '#b3b3b3',
+        fontSize: '13px',
+      }}
+    >
+      {/* 체크 아이콘 왼쪽 위 고정 */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 19,
+          left: 15,
+        }}
+      >
+        <img src={CheckIcon} alt="check icon" />{' '}
+      </div>
+
+      {/* '예약 접수 완료' 중앙 정렬 */}
+      <div
+        style={{
+          textAlign: 'left',
+          fontWeight: 800,
+          fontSize: '22px',
+          color: '#222',
+          marginBottom: 18,
+          marginTop: 38,
+          letterSpacing: '-2px',
+        }}
+      >
+        예약 접수 완료
+      </div>
+
+      {/* 예약 정보 영역 */}
+      <div style={{ marginLeft: 0 }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: 1,
+          }}
+        >
+          <span style={{ color: '#C0C0C0', fontWeight: 600 }}>고객명</span>
+          <span style={{ color: '#222', fontWeight: 600 }}>{name}</span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: 1,
+          }}
+        >
+          <span style={{ color: '#C0C0C0', fontWeight: 600, letterSpacing: '-0.5px' }}>
+            예약 날짜
+          </span>
+          <span style={{ color: '#F08080', fontWeight: 600, letterSpacing: '-0.5px' }}>{date}</span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: 1,
+          }}
+        >
+          <span style={{ color: '#C0C0C0', fontWeight: 600, letterSpacing: '-0.5px' }}>
+            예약 시간
+          </span>
+          <span style={{ color: '#F08080', fontWeight: 600 }}>{time}</span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span style={{ color: '#C0C0C0', fontWeight: 600, letterSpacing: '-0.5px' }}>
+            첨부 사진
+          </span>
+          <span style={{ color: '#C0C0C0', fontWeight: 600 }}>{photoCount}장</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/query/reservationQueries.js
+++ b/src/query/reservationQueries.js
@@ -11,11 +11,25 @@ export const useReservationForm = (shopId, enabled) => {
 };
 
 //예약 생성 훅
-export const useCreateReservation = () => {
+export const useCreateReservation = (onReservationComplete, handleClose, formDataRef) => {
   return useMutation({
     mutationFn: (payload) => reservationService.createReservation(payload),
     onSuccess: () => {
       alert('예약이 완료되었습니다!');
+
+      //예약 완료 메시지 생성
+      const current = formDataRef?.current;
+      if (current) {
+        onReservationComplete?.({
+          name: current.basic?.name || '',
+          date: current.basic?.date || '',
+          time: current.basic?.time || '',
+          photoCount: current.photoNote?.files?.length || 0,
+        });
+      }
+
+      //모달 닫기까지 훅 내부에서 처리
+      handleClose?.();
     },
 
     onError: (error) => {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 예약 생성후 예약 전송 메시지 추가

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 예약을 생성한 사용자는 채팅방 메시지에 예약 전송 완료 메시지를 볼 수 있도록 로직을 추가

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #67 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---
<img width="355" height="761" alt="image" src="https://github.com/user-attachments/assets/8120c146-c56f-48bb-b31d-28cd59037b87" />



## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-아직 예약 전송 완료 메시지 관련 api가 없어서 실제 백앤드로 부터 예약 완료 메시지를 불러오지 못하고 있는데 추후에 api에 추가된다면 실제 연동하는 방식으로 수정 예정
