### PR TITLE
채팅 마지막 메시지길이에 따른 UI 깨짐 문제 해결 후 배포

### DIFF
--- a/src/components/chat/ChatRoomItem.jsx
+++ b/src/components/chat/ChatRoomItem.jsx
@@ -1,5 +1,9 @@
 import { useNavigate } from 'react-router-dom';
+import { truncateByVisualLength } from '../../utils/truncateByVisualLength';
 import * as S from './ChatRoomItem.styles';
+
+//메시지 최대 길이
+const MAX_LENGTH = 30;
 
 export default function ChatRoomItem({ room }) {
   const navigate = useNavigate();
@@ -9,6 +13,9 @@ export default function ChatRoomItem({ room }) {
   const handleClick = () => {
     navigate(`/chat/${room.chatRoomId}`);
   };
+
+  //일정 길이 이상일때 마지막 메시지 길이 줄이기
+  const shortMessage = truncateByVisualLength(lastMessageContent, MAX_LENGTH);
 
   return (
     <S.Container>
@@ -24,7 +31,7 @@ export default function ChatRoomItem({ room }) {
           </S.Time>
         </S.TopRow>
         <S.BottomRow>
-          <S.LastMessage>{lastMessageContent}</S.LastMessage>
+          <S.LastMessage>{shortMessage}</S.LastMessage>
           {unreadCount > 0 && <S.UnreadBadge>{unreadCount}</S.UnreadBadge>}
         </S.BottomRow>
       </S.InfoWrapper>

--- a/src/components/chat/ChatRoomItem.styles.js
+++ b/src/components/chat/ChatRoomItem.styles.js
@@ -56,9 +56,6 @@ export const Time = styled.span`
 export const LastMessage = styled.span`
   flex: 1;
   font-size: 13px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: ${theme.colors.gray.dark.DEFAULT};
 `;
 

--- a/src/utils/truncateByVisualLength.js
+++ b/src/utils/truncateByVisualLength.js
@@ -1,0 +1,20 @@
+//채팅 마지막 메시지 길이 제어 함수
+export function truncateByVisualLength(str, maxLength) {
+  let visualLen = 0; // 화면상 누적 폭
+  let result = ''; // 잘라낸 문자열 결과
+
+  for (const ch of str) {
+    // 한글, 한자, 일본어 폭 2로 계산, 나머지 폭 1로 계산
+    visualLen += /[ㄱ-ㅎ가-힣\u3131-\uD79D\u4E00-\u9FFF]/.test(ch) ? 2 : 1;
+
+    //폭 기준으로 초과한 시점
+    if (visualLen > maxLength) {
+      result += '…';
+      break;
+    }
+
+    result += ch;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 채팅 마지막 메시지길이에 따른 UI 깨짐 문제 해결

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 메시지 길이 제어함수를 구성해서 채팅방 목록에서 각 한글, 영어 폭에 따라 마지막 메시지 길이를 제어해서 채팅방 목록 UI가 옆으로 깨지는 것을 방지

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #70 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->
<img width="371" height="764" alt="image" src="https://github.com/user-attachments/assets/d2865693-b364-4df7-b833-c66e5d88d8a7" />

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
