### PR TITLE
고객 입장 채팅방 예약 목록 메뉴 표시 후 배포

### DIFF
--- a/src/assets/icons/reservation-list-icon.svg
+++ b/src/assets/icons/reservation-list-icon.svg
@@ -1,0 +1,10 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="35" cy="35" r="34" stroke="#D3D3D3" stroke-width="2"/>
+<rect x="21" y="17" width="27" height="33" rx="7" fill="white"/>
+<rect x="22.5" y="18.5" width="24" height="30" rx="5.5" stroke="black" stroke-opacity="0.75" stroke-width="3"/>
+<rect x="27" y="23" width="15" height="2" rx="1" fill="black" fill-opacity="0.75"/>
+<rect x="27" y="27" width="9" height="2" rx="1" fill="black" fill-opacity="0.75"/>
+<rect x="27" y="31" width="3" height="2" rx="1" fill="black" fill-opacity="0.75"/>
+<path d="M41 32.5C45.6263 32.5 49.5 36.4596 49.5 41.5C49.5 46.5404 45.6263 50.5 41 50.5C36.3737 50.5 32.5 46.5404 32.5 41.5C32.5 36.4596 36.3737 32.5 41 32.5Z" fill="white" stroke="#F08080" stroke-width="3"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M41.0127 37.2627C41.6013 37.2628 42.0781 37.7405 42.0781 38.3291V40.5791H44.1709C44.781 40.5793 45.2752 41.0735 45.2754 41.6836C45.2754 42.2939 44.7811 42.7888 44.1709 42.7891H41.0518C40.4796 42.7889 40.0087 42.3542 39.9521 41.7969L39.9473 41.6836V38.3291C39.9473 37.7405 40.4241 37.2627 41.0127 37.2627Z" fill="#F08080"/>
+</svg>

--- a/src/components/chat/AddMenuButton.jsx
+++ b/src/components/chat/AddMenuButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import addIcon from '../../assets/icons/add-icon.svg';
+import { AddButton } from './chatIconButton';
+
+export default function AddMenuButton({ onToggleMenu }) {
+  const handleClick = () => {
+    onToggleMenu?.(); // 부모에서 전달한 메뉴 토글 콜백
+  };
+
+  return (
+    <AddButton onClick={handleClick}>
+      <img src={addIcon} alt="addMenu" />
+    </AddButton>
+  );
+}

--- a/src/components/chat/ChatMenuPanel.jsx
+++ b/src/components/chat/ChatMenuPanel.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+import reservationListIcon from '../../assets/icons/reservation-list-icon.svg';
+import { BaseButton } from '../common/Button';
+
+export default function ChatMenuPanel({ visible }) {
+  return (
+    <Panel $visible={visible}>
+      <PanelInner>
+        <ReservationListButton $column>
+          <img src={reservationListIcon} alt="reservationListIcon" />
+          <span>예약 내역</span>
+        </ReservationListButton>
+      </PanelInner>
+    </Panel>
+  );
+}
+
+export const Panel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  bottom: 59px; /* InputBar 높이 */
+  left: 0;
+  width: 100%;
+  height: 180px;
+  background: #f3f3f3;
+  border-top: 1px solid #ddd;
+  transition: all 0.3s ease;
+  padding: 16px;
+  z-index: ${({ $visible }) => ($visible ? 15 : -1)}; /* 닫힐 땐 완전히 뒤로 */
+  /* 메뉴가 보이거나 숨겨질 때 부드럽게 */
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transform: ${({ $visible }) => ($visible ? 'translateY(0)' : 'translateY(100%)')};
+`;
+
+const PanelInner = styled.div``;
+
+const ReservationListButton = styled(BaseButton)``;

--- a/src/components/chat/chatIconButton.js
+++ b/src/components/chat/chatIconButton.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import theme from '../../styles/theme';
+import { BaseButton } from '../../components/common/Button';
+
+export const ChatIconButton = styled(BaseButton).attrs({
+  $height: '31px',
+  $radius: '9999px',
+})`
+  width: 31px;
+  padding: 0px;
+  background-color: ${theme.colors.primary};
+  color: white;
+`;
+
+export const AddButton = styled(ChatIconButton)`
+  margin-right: 10px;
+`;
+
+export const ChatButton = styled(ChatIconButton)`
+  margin-left: 10px;
+`;

--- a/src/components/chat/chatSumbitButton.jsx
+++ b/src/components/chat/chatSumbitButton.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import sendIcon from '../../assets/icons/send-icon.svg';
+import { ChatButton } from './chatIconButton';
+
+export default function ChatSumbitButton({ onClick }) {
+  return (
+    <ChatButton onClick={onClick}>
+      <img src={sendIcon} alt="addMenu" />
+    </ChatButton>
+  );
+}

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -19,21 +19,27 @@ import { useInitScrollToBottom } from '../../hooks/chat/useInitScrollToBottom';
 import { useTopObserver } from '../../hooks/chat/useTopObserver';
 import { useShopInfoByCode } from '../../query/linkQueries';
 import { ReservationCompleteMessage } from '../../components/message/ReservationCompleteMessage';
+import AddMenuButton from '../../components/chat/AddMenuButton';
+import ChatMenuPanel from '../../components/chat/ChatMenuPanel';
+import ChatSumbitButton from '../../components/chat/chatSumbitButton';
 
 export default function ChatRoomPage() {
   const [input, setInput] = useState('');
   const [liveMessages, setLiveMessages] = useState([]);
   const [readyToObserve, setReadyToObserve] = useState(false);
 
-  //링크 유입시 가게 정보 조회
-  const [searchParams] = useSearchParams();
-  const slugOrCode = searchParams.get('slug');
-  const { data: shopInfo } = useShopInfoByCode(slugOrCode);
-
   //예약 모달 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
+
+  //메뉴 표시 여부 상태
+  const [showMenu, setShowMenu] = useState(false);
+
+  //링크 유입시 가게 정보 조회
+  const [searchParams] = useSearchParams();
+  const slugOrCode = searchParams.get('slug');
+  const { data: shopInfo } = useShopInfoByCode(slugOrCode);
 
   const handleBack = () => {
     if (window.history.state && window.history.state.idx > 0) {
@@ -41,6 +47,14 @@ export default function ChatRoomPage() {
     } else {
       navigate('/'); // 외부 유입이라 이전 기록 없을 때 홈으로(링크 유입)
     }
+  };
+
+  //버튼 토글 핸들러
+  const handleToggleMenu = () => {
+    // 메뉴 표시/숨김 토글
+    setTimeout(() => {
+      setShowMenu((prev) => !prev);
+    }, 150);
   };
 
   const { auth } = useAuth();
@@ -245,20 +259,22 @@ export default function ChatRoomPage() {
           {/* 하단 스크롤 고정용 */}
           <div ref={bottomRef} />
         </S.MessageList>
+        {/* 채팅 메뉴 패널 */}
+        <ChatMenuPanel visible={showMenu} />
 
         <S.InputBar>
-          <S.AddButton>
-            <img src={addIcon} alt="addMenu" />
-          </S.AddButton>
+          {/* 채팅 메뉴 목록 버튼 */}
+          <AddMenuButton onToggleMenu={handleToggleMenu} />
+          {/* 채팅 입력 바 */}
           <S.ChatInput
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleSend()}
             maxLength={300}
+            onFocus={() => setShowMenu(false)} //키보드 열릴때 메뉴 닫기
           />
-          <S.ChatButton onClick={handleSend}>
-            <img src={sendIcon} alt="send" />
-          </S.ChatButton>
+          {/*채팅 전송 버튼*/}
+          <ChatSumbitButton onClick={handleSend} />
         </S.InputBar>
       </S.PageWrapper>
       {/*예약 모달 */}

--- a/src/pages/chat/ChatRoomPage.style.js
+++ b/src/pages/chat/ChatRoomPage.style.js
@@ -71,24 +71,6 @@ export const ChatInput = styled(BaseInput).attrs({
   flex: 1;
 `;
 
-export const ChatIconButton = styled(BaseButton).attrs({
-  $height: '31px',
-  $radius: '9999px',
-})`
-  width: 31px;
-  padding: 0px;
-  background-color: ${theme.colors.primary};
-  color: white;
-`;
-
-export const AddButton = styled(ChatIconButton)`
-  margin-right: 10px;
-`;
-
-export const ChatButton = styled(ChatIconButton)`
-  margin-left: 10px;
-`;
-
 export const MessageRow = styled.div`
   display: flex;
   justify-content: ${({ $isMine }) => ($isMine ? 'flex-end' : 'flex-start')};


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 메뉴 패널을 이용한 예약 내역 조회 버튼 표시

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 채팅 input바 왼족에 +메뉴 버튼을 누를시 메뉴 패널이 아래에서 올라와 예약 내역 조회 버튼이 보이도록 구성
- 메뉴 패널이 올라올 떄 애니메이션을 적용해 부드럽게 올라오도록 적용
- 채팅 input바 활성화 시 메뉴 패널 닫히게 적용
- input바 양옆 버튼을 세분화 해서 컴포넌트 구성

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #76 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->
<img width="398" height="784" alt="image" src="https://github.com/user-attachments/assets/86d309a7-ef43-4082-b221-5172150f2099" />

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-아직 백앤드 쪽 api가 구현되지 않아 추후 업데이트 시 api 연동 할 계획
