### PR TITLE
점주 채팅방 목록 해당 고객 이름 표시  후 배포 

### DIFF
--- a/src/components/chat/ChatRoomItem.jsx
+++ b/src/components/chat/ChatRoomItem.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { truncateByVisualLength } from '../../utils/truncateByVisualLength';
 import * as S from './ChatRoomItem.styles';
+import { useAuth } from '../../context/AuthContext';
 
 //메시지 최대 길이
 const MAX_LENGTH = 30;
@@ -8,6 +9,8 @@ const MAX_LENGTH = 30;
 export default function ChatRoomItem({ room }) {
   const navigate = useNavigate();
   const { shopBusinessName, otherUserName, lastMessageContent, lastMessageAt, unreadCount } = room;
+  //현재 유저 정보 전역 상태
+  const { auth } = useAuth();
 
   //해당 채팅방 이동 헨들러
   const handleClick = () => {
@@ -22,7 +25,7 @@ export default function ChatRoomItem({ room }) {
       <S.Avatar>{otherUserName[0]}</S.Avatar>
       <S.InfoWrapper onClick={handleClick}>
         <S.TopRow>
-          <S.ShopName>{shopBusinessName}</S.ShopName>
+          <S.ShopName>{auth.userType === 'OWNER' ? otherUserName : shopBusinessName}</S.ShopName>
           <S.Time>
             {new Date(lastMessageAt).toLocaleTimeString('ko-KR', {
               hour: '2-digit',


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 점주 채팅방 목록 해당 고객 이름 표시

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 현재 점주, 고객 구분없이 채팅방 타이틀은 가게이름이었는데 점주는 해당 고객이름, 고객은 가게이름으로 채팅방 목록에서 볼 수 있도록 처리

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #101 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->
<img width="363" height="738" alt="image" src="https://github.com/user-attachments/assets/223c397e-95d0-4e8e-988a-c81577e8618c" />

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 채팅방 목록에서 사용자 유형에 따라 적절한 상호명을 표시하도록 개선되었습니다. 가게 소유자는 상대방 이름을, 일반 사용자는 가게 사업명을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->