### PR TITLE
feat: 예약 시간 입력 제한

### DIFF
--- a/src/components/reservation/StepBasic.jsx
+++ b/src/components/reservation/StepBasic.jsx
@@ -43,6 +43,73 @@ export default function StepBasic({ initialData, onNext, visibleFields }) {
     setValues((v) => ({ ...v, phoneNumber: sanitizePhone(e.target.value) }));
   };
 
+  const STEP_MIN = 30;
+  const OPEN_TIME = "09:00";
+  const CLOSE_TIME = "22:00";
+
+  const pad2 = (n) => String(n).padStart(2, "0");
+
+  // 30분 간격 타임슬롯 생성 (영업시간 + 오늘이면 현재 이후만)
+  const buildTimeSlots = (dateStr, stepMin = STEP_MIN, open = OPEN_TIME, closeExclusive = CLOSE_TIME) => {
+    const toMinutes = (hhmm) => {
+      const [h, m] = hhmm.split(":").map(Number);
+      return h * 60 + m;
+    };
+    const fromMinutes = (mins) => `${pad2(Math.floor(mins / 60))}:${pad2(mins % 60)}`;
+
+    let startMin = toMinutes(open);
+    const lastStartMin = toMinutes(closeExclusive) - stepMin; // 22:00 시작 금지 → 21:30까지 허용
+
+    // 오늘이면 현재시간의 다음 30분 경계부터 시작  →  오늘이면 '현재시간 + 1시간' 이후부터 시작
+    if (dateStr && dateStr === todayYMD()) {
+      const now = new Date();
+      const nowMin = now.getHours() * 60 + now.getMinutes();
+
+      // 1시간(60분) 이후를 기준으로 잡기
+      const OFFSET_MIN = 60;
+      const targetMin = nowMin + OFFSET_MIN;
+
+      // targetMin 이후의 가장 가까운 30분 단위로 올림
+      const ceilToStep = Math.ceil(targetMin / stepMin) * stepMin;
+
+      // 영업 시작 시간(startMin)과 비교해서 더 늦은 쪽을 시작 시각으로
+      startMin = Math.max(startMin, ceilToStep);
+    }
+
+
+    if (startMin > lastStartMin) return []; // 오늘 남은 슬롯이 없을 때
+
+    const slots = [];
+    for (let m = startMin; m <= lastStartMin; m += stepMin) {
+      slots.push(fromMinutes(m));
+    }
+    return slots;
+  };
+
+  const timeOptions = useMemo(
+    () => buildTimeSlots(values.date, STEP_MIN, OPEN_TIME, CLOSE_TIME),
+    [values.date]
+  );
+
+  // 옵션 리스트가 바뀌었을 때, 현재 선택값이 범위 밖이면 비웁니다.
+  useEffect(() => {
+    if (values.time && !timeOptions.includes(values.time)) {
+      setValues((v) => ({ ...v, time: "" }));
+    }
+  }, [timeOptions]); 
+
+  useEffect(() => {
+    // timeOptions: 09:00~21:30, 오늘이면 현재 이후부터
+    if (!values.date) return;
+    if (timeOptions.length === 0) {
+      if (values.time) setValues(v => ({ ...v, time: '' }));
+      return;
+    }
+    if (!values.time || !timeOptions.includes(values.time)) {
+      setValues(v => ({ ...v, time: timeOptions[0] })); // 허용된 첫 슬롯 자동 선택
+    }
+  }, [values.date, timeOptions]);
+
   // 검증들
   const phoneValid = validateMobile010(values.phoneNumber).valid;
   const dateTimeCheck = validateReservationDateTime(values.date, values.time);
@@ -95,12 +162,16 @@ export default function StepBasic({ initialData, onNext, visibleFields }) {
           min={todayYMD()}
           onChange={(e) => setValues((v) => ({ ...v, date: e.target.value }))}
         />
-        <input
+        <select
           className="field"
-          type="time"
           value={values.time}
           onChange={(e) => setValues((v) => ({ ...v, time: e.target.value }))}
-        />
+        >
+          <option value="" disabled>시간 선택</option>
+          {timeOptions.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
       </div>
 
       {/* 날짜/시간 에러 메시지 */}


### PR DESCRIPTION

## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 오전 9시 이전, 오후 10시부터 예약 불가
- 예약을 30분 단위로 할 수 있게 변경
- 당일 예약 시 현재 시간 기준 1시간 후부터 예약이 가능

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 오픈 시간을 9시, 마감 시간을 22시로 설정해서 9시 이전, 22시부터 예약이 불가하게 막았고, 기존에 1분 간격으로 예약할 수 있었던 간격을 30분 간격으로 수정하여 예약을 받을 수 있게 설정함. 그리고 당일 예약 시 현재 시간 기준으로 1시간 후부터 예약이 가능하게 수정함. (예약을 시도하는 시간이 14:01 일 때 예약할 수 있는 가장 가까운 시간은 15:30 이 됨.)

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #95 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->
<img width="409" height="831" alt="image" src="https://github.com/user-attachments/assets/98a9d987-8c43-4817-9c6e-01408d3d2650" />

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
