### PR TITLE
엑세스 토큰 재발급, 리프레쉬 만료시 로그인 처리 구현

### DIFF
--- a/src/api/axiosClient.js
+++ b/src/api/axiosClient.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
 import { authStorage } from '../utils/auth/authStorage';
+
+let isRefreshing = false;
+let refreshQueue = [];
+
 const axiosClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
@@ -9,5 +13,70 @@ axiosClient.interceptors.request.use((config) => {
   if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
 });
+
+// 응답 인터셉터: 401 처리(엑세스 토큰 만료)
+axiosClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config;
+    // access 토큰 만료 + 최초 재시도
+    if (error.response?.status === 401 && !original._retry) {
+      original._retry = true;
+
+      const refreshToken = authStorage.getRefreshToken();
+
+      if (!refreshToken) {
+        authStorage.clear();
+        window.location.href = '/';
+        return;
+      }
+
+      // 이미 refresh 진행 중이면 큐에 적재
+      if (isRefreshing) {
+        console.log('already refreshing → queue push');
+
+        return new Promise((resolve) => {
+          refreshQueue.push((newAccessToken) => {
+            original.headers['Authorization'] = `Bearer ${newAccessToken}`;
+            resolve(axiosClient(original));
+          });
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        console.log('refresh API 호출');
+        // refresh API 호출
+        const res = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/auth/refresh`, {
+          token: refreshToken,
+        });
+
+        // 전체 auth 데이터 저장
+        authStorage.save(res.data);
+
+        // 새 accessToken 추출
+        const newAccessToken = authStorage.getAccessToken();
+        // 대기중인 요청 처리
+        refreshQueue.forEach((cb) => cb(newAccessToken));
+        refreshQueue = [];
+        isRefreshing = false;
+
+        // 원래 요청 재실행
+        original.headers['Authorization'] = `Bearer ${newAccessToken}`;
+        return axiosClient(original);
+      } catch (refreshError) {
+        // refresh 실패: 로그인 필요
+        isRefreshing = false;
+        refreshQueue = [];
+        authStorage.clear();
+        window.location.href = '/';
+        return;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default axiosClient;


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 엑세스 토큰 재발급, 리프레쉬 만료시 로그인 처리 구현

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 엑세스 토큰이 만료가 되면 401상태코드로 응답이 오게되면 aciosClient의 응답 인터셉터에서 리프레쉬 토큰을 통해 엑세스 토큰을 포함한 전체 사용자 정보를 다시 불러오고 기존의 응답 또한 새로 발급 받은 엑세스 토큰으로 진행할 수 있게 한다. 

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #106 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
