### PR TITLE
예약 상태 메시지 중복 문제 해결 후 배포

### DIFF
--- a/src/components/message/MessageItem.jsx
+++ b/src/components/message/MessageItem.jsx
@@ -19,8 +19,6 @@ export default function MessageItem({ msg, isMine }) {
     let CardComponent = null;
 
     switch (msg.type) {
-      //TODO: 예약 상태 메시지 api 통합 적용 후 타입하나로 추후에 수정 예정
-      case 'PENDING':
       case 'RESERVATION_CREATED':
         // 점주 → 수락/거절 카드
         if (isOwner) {
@@ -39,7 +37,7 @@ export default function MessageItem({ msg, isMine }) {
 
         break;
 
-      case 'CONFIRMED':
+      case 'RESERVATION_CONFIRMED':
         CardComponent = (
           <DecisionCard
             variant="approved"
@@ -51,7 +49,7 @@ export default function MessageItem({ msg, isMine }) {
         );
         break;
 
-      case 'REJECTED':
+      case 'RESERVATION_REJECTED':
         CardComponent = (
           <DecisionCard
             variant="rejected"

--- a/src/hooks/chat/useNormalizedMessages.js
+++ b/src/hooks/chat/useNormalizedMessages.js
@@ -28,7 +28,7 @@ export function useNormalizedMessages(rawMessages) {
               messageId: msg.messageId,
               sentAt: msg.sentAt,
               isReservationCard: true,
-              type: r.status,
+              type: msg.messageType,
               payload: r,
             };
             cacheRef.current.set(msg.reservationId, converted);

--- a/src/hooks/chat/useReservationSocketHandler.js
+++ b/src/hooks/chat/useReservationSocketHandler.js
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { reservationService } from '../../api/services/reservationService';
+
+const RESERVATION_MESSAGE_TYPES = [
+  'RESERVATION_CREATED',
+  'RESERVATION_CONFIRMED',
+  'RESERVATION_REJECTED',
+];
+
+export function useReservationSocketHandler(setLiveMessages) {
+  const handleReservationMessage = useCallback(
+    async (incoming) => {
+      // 예약 메시지가 아니면 처리 안 함
+      if (!RESERVATION_MESSAGE_TYPES.includes(incoming.messageType)) {
+        return false;
+      }
+
+      try {
+        const reservation = await reservationService.getReservationById(incoming.reservationId);
+
+        setLiveMessages((prev) => {
+          return [
+            ...prev,
+            {
+              messageId: incoming.messageId,
+              senderId: incoming.senderId,
+              senderName: incoming.senderName,
+              sentAt: incoming.sentAt,
+
+              isReservationCard: true,
+              type: incoming.messageType, // 예약 상태의  기준
+              payload: {
+                id: incoming.reservationId,
+                customerName: reservation.customerName,
+                date: reservation.date,
+                time: reservation.time,
+                photoCount: reservation.photoCount,
+                photoUrls: reservation.photoUrls,
+                part: reservation.part,
+                removal: reservation.removal,
+                requests: reservation.requests,
+                extendCount: reservation.extendCount,
+                wrappingCount: reservation.wrappingCount,
+                extendStatus: reservation.extendStatus,
+                wrappingStatus: reservation.wrappingStatus,
+                confirmationMessage: reservation.confirmationMessage,
+                rejectionReason: reservation.rejectionReason,
+              },
+            },
+          ];
+        });
+
+        return true;
+      } catch (e) {
+        console.error('예약 단건 조회 실패', e);
+        return true; // 예약 메시지였으니 여기서 소비
+      }
+    },
+    [setLiveMessages]
+  );
+
+  return { handleReservationMessage };
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 예약 상태 메시지 중복 문제 해결

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- 메시지에서 예약id로 예약 정보를 가져와서 그 정보에서 예약 상태를 판별했는데 메시지타입으로 예약 상태를 판별해서 예약 메시지가 상태에 따라 중복되는 문제를 해결했고, 예약 거절, 확정 또한 실시간으로 추가될 수 있도록 수정함 

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #151 

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->

---


## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 예약 관련 메시지 처리 기능 추가로 예약 상태 업데이트 개선

* **리팩토링**
  * 예약 카드 타입 분류 체계 개선
  * 중복 메시지 제거 로직 추가로 채팅 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->