### PR TITLE
점주 회원가입 메뉴 연결 시 상점 태그 id 사용하도록 수정

### DIFF
--- a/src/api/services/menuService.js
+++ b/src/api/services/menuService.js
@@ -48,22 +48,22 @@ export const menuService = {
    * 메뉴에 태그 연결
    * @param {number} shopId - 상점 ID (path param)
    * @param {number} menuId - 메뉴 ID (path param)
-   * @param {number} tagId - 태그 ID
+   * @param {number} shopTagId - /api/shops/{shopId}/tags 에서 받은 상점 태그 ID
    * @returns {Promise<void>}
    */
-  linkMenuTag: async (shopId, menuId, tagId) => {
-    await axiosClient.post(`/api/shops/${shopId}/menus/${menuId}/tags`, { tagId });
+  linkMenuTag: async (shopId, menuId, shopTagId) => {
+    await axiosClient.post(`/api/shops/${shopId}/menus/${menuId}/tags`, { tagId: shopTagId });
   },
 
   /**
    * 태그에서 메뉴 제거
    * @param {number} shopId - 상점 ID (path param)
    * @param {number} menuId - 메뉴 ID (path param)
-   * @param {number} tagId - 태그 ID (path param)
+   * @param {number} shopTagId - 상점 태그 ID (path param)
    * @returns {Promise<void>}
    */
-  unlinkMenuTag: async (shopId, menuId, tagId) => {
-    await axiosClient.delete(`/api/shops/${shopId}/menus/${menuId}/tags/${tagId}`);
+  unlinkMenuTag: async (shopId, menuId, shopTagId) => {
+    await axiosClient.delete(`/api/shops/${shopId}/menus/${menuId}/tags/${shopTagId}`);
   },
 
   /**

--- a/src/api/services/tagService.js
+++ b/src/api/services/tagService.js
@@ -2,9 +2,9 @@ import axiosClient from '../axiosClient';
 
 export const tagService = {
   /**
-   * 태그(카테고리) 생성
+   * 전역 태그(카테고리) 생성
    * @param {string} name - 태그 이름
-   * @returns {Promise<Object>} 생성된 태그 정보
+   * @returns {Promise<Object>} 생성된 전역 태그 정보
    */
   createTag: async (name) => {
     const res = await axiosClient.post('/api/tags', { name });
@@ -12,11 +12,32 @@ export const tagService = {
   },
 
   /**
-   * 태그(카테고리) 목록 조회
-   * @returns {Promise<Array>} 태그 목록 [{id, name}, ...]
+   * 전역 태그(카테고리) 목록 조회
+   * @returns {Promise<Array>} 전역 태그 목록 [{id, name}, ...]
    */
   getTags: async () => {
     const res = await axiosClient.get('/api/tags');
+    return res.data;
+  },
+
+  /**
+   * 상점별 태그(카테고리) 생성
+   * @param {number} shopId - 상점 ID
+   * @param {string} name - 태그 이름
+   * @returns {Promise<Object>} 생성된 상점 태그 정보
+   */
+  createShopTag: async (shopId, name) => {
+    const res = await axiosClient.post(`/api/shops/${shopId}/tags`, { name });
+    return res.data;
+  },
+
+  /**
+   * 상점별 태그(카테고리) 목록 조회
+   * @param {number} shopId - 상점 ID
+   * @returns {Promise<Array>} 상점 태그 목록 [{id, name}, ...]
+   */
+  getShopTags: async (shopId) => {
+    const res = await axiosClient.get(`/api/shops/${shopId}/tags`);
     return res.data;
   },
 };

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,17 +1,53 @@
 import { http, HttpResponse } from 'msw';
 
 const BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+const globalTags = [{ id: 4, name: '손관리' }];
+const shopTagsByShopId = {
+  1: [
+    { id: 1, name: '네일' },
+    { id: 3, name: '왁싱' },
+    { id: 4, name: '치킨' },
+    { id: 5, name: '피자' },
+    { id: 7, name: '짜장면' },
+  ],
+  65: [{ id: 101, name: '손관리' }],
+};
+let nextGlobalTagId = 5;
+let nextShopTagId = 102;
 
 export const handlers = [
+  // 전역 태그 정의 목록 조회
+  http.get(`${BASE}/api/tags`, () => {
+    return HttpResponse.json(globalTags);
+  }),
+
+  // 전역 태그 정의 생성
+  http.post(`${BASE}/api/tags`, async ({ request }) => {
+    const { name } = await request.json();
+    const created = { id: nextGlobalTagId++, name };
+    globalTags.push(created);
+    return HttpResponse.json(created, { status: 201 });
+  }),
+
   // 상점별 태그(카테고리) 목록 조회
-  http.get(`${BASE}/api/shops/:shopId/tags`, () => {
-    return HttpResponse.json([
-      { id: 1, name: '네일' },
-      { id: 3, name: '왁싱' },
-      { id: 4, name: '치킨' },
-      { id: 5, name: '피자' },
-      { id: 7, name: '짜장면' },
-    ]);
+  http.get(`${BASE}/api/shops/:shopId/tags`, ({ params }) => {
+    const shopId = String(params.shopId);
+    return HttpResponse.json(shopTagsByShopId[shopId] ?? []);
+  }),
+
+  // 상점별 태그(카테고리) 생성
+  http.post(`${BASE}/api/shops/:shopId/tags`, async ({ params, request }) => {
+    const shopId = String(params.shopId);
+    const { name } = await request.json();
+
+    if (!shopTagsByShopId[shopId]) {
+      shopTagsByShopId[shopId] = [];
+    }
+
+    const created = { id: nextShopTagId++, name };
+    shopTagsByShopId[shopId].push(created);
+
+    return HttpResponse.json(created, { status: 201 });
   }),
 
   // 태그(카테고리)별 메뉴 목록 조회
@@ -91,5 +127,31 @@ export const handlers = [
     };
 
     return HttpResponse.json(menusByTag[tagIds] || []);
+  }),
+
+  // 메뉴에 태그 연결
+  http.post(`${BASE}/api/shops/:shopId/menus/:menuId/tags`, async ({ params, request }) => {
+    const shopId = String(params.shopId);
+    const { tagId } = await request.json();
+    const shopTags = shopTagsByShopId[shopId] ?? [];
+
+    const matchedShopTag = shopTags.find((tag) => tag.id === tagId);
+    if (!matchedShopTag) {
+      return HttpResponse.json(
+        {
+          code: 'SHOP_TAG_MISMATCH',
+          message: '메뉴 연결에는 상점 태그 ID를 사용해야 합니다.',
+        },
+        { status: 400 }
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        menuId: Number(params.menuId),
+        tagId,
+      },
+      { status: 201 }
+    );
   }),
 ];

--- a/src/query/shopManage/menuQueries.js
+++ b/src/query/shopManage/menuQueries.js
@@ -69,7 +69,8 @@ export const useDeactivateShopMenu = () => {
  */
 export const useLinkMenuTag = () => {
   return useMutation({
-    mutationFn: ({ shopId, menuId, tagId }) => menuService.linkMenuTag(shopId, menuId, tagId),
+    mutationFn: ({ shopId, menuId, shopTagId }) =>
+      menuService.linkMenuTag(shopId, menuId, shopTagId),
     onError: (error) => {
       console.error('태그 연결 실패:', error);
       alert('태그 연결 중 오류가 발생했습니다.');
@@ -82,7 +83,8 @@ export const useLinkMenuTag = () => {
  */
 export const useUnlinkMenuTag = () => {
   return useMutation({
-    mutationFn: ({ shopId, menuId, tagId }) => menuService.unlinkMenuTag(shopId, menuId, tagId),
+    mutationFn: ({ shopId, menuId, shopTagId }) =>
+      menuService.unlinkMenuTag(shopId, menuId, shopTagId),
     onSuccess: () => {
       alert('메뉴가 태그에서 제거되었습니다.');
     },

--- a/src/query/shopManage/tagQueries.js
+++ b/src/query/shopManage/tagQueries.js
@@ -2,24 +2,25 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { tagService } from '../../api/services/tagService';
 
 /**
- * 태그(카테고리) 목록 조회 훅
+ * 상점별 태그(카테고리) 목록 조회 훅
  */
-export const useShopManageTags = () => {
+export const useShopManageTags = (shopId) => {
   return useQuery({
-    queryKey: ['shop-manage-tags'],
-    queryFn: () => tagService.getTags(),
+    queryKey: ['shop-manage-tags', shopId],
+    queryFn: () => tagService.getShopTags(shopId),
+    enabled: !!shopId,
   });
 };
 
 /**
- * 태그(카테고리) 생성 훅
+ * 상점별 태그(카테고리) 생성 훅
  */
 export const useCreateShopTag = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (name) => tagService.createTag(name),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shop-manage-tags'] });
+    mutationFn: ({ shopId, name }) => tagService.createShopTag(shopId, name),
+    onSuccess: (_, { shopId }) => {
+      queryClient.invalidateQueries({ queryKey: ['shop-manage-tags', shopId] });
     },
     onError: (error) => {
       console.error('태그 생성 실패:', error);

--- a/src/query/signupQueries.js
+++ b/src/query/signupQueries.js
@@ -79,15 +79,15 @@ export const useOwnerSignupFlow = () => {
       throw error;
     }
 
-    // 6) 태그(카테고리) 생성 → 메뉴 생성 → 메뉴-태그 연결 (실패 시 롤백 없음)
-    const tagMap = {}; // tagName → tagId
+    // 6) 상점 태그(카테고리) 생성 → 메뉴 생성 → 메뉴-태그 연결 (실패 시 롤백 없음)
+    const tagMap = {}; // tagName → shopTagId
     let sortOrder = 1;
     try {
       for (const { tagName, menuName, description, inputFields = [] } of menuItems) {
-        //태그 중복 생성 제어
+        // 같은 이름의 상점 태그는 한 번만 만들고 재사용한다.
         if (!tagMap[tagName]) {
-          const tag = await createShopTag.mutateAsync(tagName);
-          tagMap[tagName] = tag.id;
+          const shopTag = await createShopTag.mutateAsync({ shopId, name: tagName });
+          tagMap[tagName] = shopTag.id;
         }
 
         //메뉴 생성
@@ -97,7 +97,11 @@ export const useOwnerSignupFlow = () => {
           description,
           sortOrder: sortOrder++,
         });
-        await linkMenuTag.mutateAsync({ shopId, menuId: menu.id, tagId: tagMap[tagName] });
+        await linkMenuTag.mutateAsync({
+          shopId,
+          menuId: menu.id,
+          shopTagId: tagMap[tagName],
+        });
 
         // 입력 필드 생성
         for (const field of inputFields) {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 간략히 설명 -->

- 운영에서 확인된 `SHOP_TAG_MISMATCH` 장애를 수정했습니다.
- 점주 회원가입 메뉴 설정 플로우에서 메뉴 연결 시 전역 태그 id가 아니라 상점 태그 id를 사용하도록 변경했습니다.

---

## 📌 작업 상세 내용
<!-- 구체적으로 어떤 기능/변경이 이루어졌는지 -->

- `tagService`에 상점별 태그 생성/조회 API를 추가했습니다.
- 점주 회원가입 메뉴 설정 플로우에서 `/api/shops/{shopId}/tags` 응답 id를 메뉴 연결 payload로 사용하도록 수정했습니다.
- 메뉴-태그 연결 관련 service/query 파라미터 의미를 상점 태그 id 기준으로 정리했습니다.
- MSW 핸들러에서 전역 태그와 상점 태그를 구분하고, 잘못된 id를 연결할 때 `SHOP_TAG_MISMATCH`가 재현되도록 보강했습니다.

---

## 📌 테스트
<!-- 실제로 실행한 테스트를 작성 -->

- `npm run build`

---

## 📌 관련 이슈
<!-- JIRA 번호 또는 GitHub Issue 번호 -->
- #168

---

## 📌 스크린샷 (선택)
<!-- UI 관련 변경이 있다면 캡쳐 첨부 -->
- 없음

---

## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가 사항 -->
- UI 변경은 없고, 점주 회원가입 시 태그 생성/메뉴 연결 API 계약을 운영 기준에 맞게 수정한 PR입니다.
- 로컬 워크트리에 남아 있던 `package-lock.json` 변경은 이번 PR에 포함하지 않았습니다.
