### PR TITLE
feat: add owner profile share link

### DIFF
--- a/src/pages/profile/Mypage.jsx
+++ b/src/pages/profile/Mypage.jsx
@@ -1,5 +1,93 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import BottomNav from '../../components/common/BottomNav';
+import Container from '../../components/common/Container';
+import Header from '../../components/common/Header';
+import { useAuth } from '../../context/AuthContext';
+import { useShopLink } from '../../query/linkQueries';
+import * as S from './Mypage.styles';
+
+const SHOP_PROFILE_LINK_BASE_URL = 'https://snapbook.store/s/';
+
+const getShopIdentifierCode = (shopLink) => {
+  if (!shopLink) return null;
+
+  if (shopLink.slug) return shopLink.slug;
+  if (shopLink.publicCode) return shopLink.publicCode;
+
+  const linkUrl = shopLink.canonicalUrl || shopLink.fullUrl;
+  const [, code] = String(linkUrl || '').match(/\/s\/([^/?#]+)/) || [];
+  return code || null;
+};
 
 export default function Mypage() {
-  return <BottomNav />;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { auth, logout } = useAuth();
+  const [copyStatus, setCopyStatus] = useState('');
+  const isOwner = auth?.userType === 'OWNER';
+  const { data: shopLink, isLoading: isShopLinkLoading, isError: isShopLinkError } = useShopLink({
+    enabled: isOwner,
+  });
+
+  const roleLabel = isOwner ? '사장님 계정' : '고객 계정';
+  const shopIdentifierCode = getShopIdentifierCode(shopLink);
+  const shopProfileLink = shopIdentifierCode
+    ? `${SHOP_PROFILE_LINK_BASE_URL}${encodeURIComponent(shopIdentifierCode)}`
+    : null;
+
+  const handleLogout = () => {
+    if (!window.confirm('로그아웃하시겠어요?')) return;
+    logout();
+    queryClient.clear();
+    navigate('/', { replace: true });
+  };
+
+  const handleCopyProfileLink = async () => {
+    if (!shopProfileLink) return;
+
+    try {
+      await navigator.clipboard.writeText(shopProfileLink);
+      setCopyStatus('공유 링크가 복사되었습니다.');
+    } catch {
+      setCopyStatus('복사에 실패했습니다. 링크를 길게 눌러 복사해주세요.');
+    }
+  };
+
+  return (
+    <Container $start $padding="23px 0">
+      <S.PageWrapper>
+        <Header title="마이페이지" />
+        <S.Content>
+          <S.AccountCard>
+            <S.Label>현재 로그인된 계정</S.Label>
+            <S.Name>{auth?.name || '이름 없음'}</S.Name>
+            <S.Meta>{auth?.phoneNumber || '전화번호 정보 없음'}</S.Meta>
+            <S.RoleBadge>{roleLabel}</S.RoleBadge>
+          </S.AccountCard>
+          {isOwner && (
+            <S.ShareLinkCard>
+              <S.Label>내 프로필 공유 링크</S.Label>
+              {isShopLinkLoading && <S.LinkStatus>공유 링크를 불러오는 중입니다.</S.LinkStatus>}
+              {isShopLinkError && (
+                <S.LinkStatus>공유 링크를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</S.LinkStatus>
+              )}
+              {!isShopLinkLoading && !isShopLinkError && shopProfileLink && (
+                <S.ShareLinkButton type="button" onClick={handleCopyProfileLink}>
+                  {shopProfileLink}
+                </S.ShareLinkButton>
+              )}
+              {copyStatus && <S.CopyStatus>{copyStatus}</S.CopyStatus>}
+              {!isShopLinkLoading && !isShopLinkError && !shopProfileLink && (
+                <S.LinkStatus>아직 공유 가능한 매장 식별 코드가 없습니다.</S.LinkStatus>
+              )}
+            </S.ShareLinkCard>
+          )}
+          <S.LogoutButton onClick={handleLogout}>로그아웃</S.LogoutButton>
+        </S.Content>
+        <BottomNav />
+      </S.PageWrapper>
+    </Container>
+  );
 }

--- a/src/pages/profile/Mypage.styles.js
+++ b/src/pages/profile/Mypage.styles.js
@@ -1,0 +1,110 @@
+import styled from 'styled-components';
+import { BaseButton } from '../../components/common/Button';
+import theme from '../../styles/theme';
+
+export const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
+  background: ${theme.colors.white};
+`;
+
+export const Content = styled.div`
+  flex: 1;
+  padding: 24px 20px 110px;
+`;
+
+export const AccountCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 24px 20px;
+  border: 1px solid ${theme.colors.gray.border};
+  border-radius: 24px;
+  background: ${theme.colors.gray[20]};
+`;
+
+export const Label = styled.span`
+  font-size: 13px;
+  font-weight: 600;
+  color: ${theme.colors.gray.dark.DEFAULT};
+`;
+
+export const Name = styled.strong`
+  font-size: 24px;
+  font-weight: 700;
+  color: ${theme.colors.black.DEFAULT};
+`;
+
+export const Meta = styled.span`
+  font-size: 15px;
+  color: ${theme.colors.gray.dark.DEFAULT};
+`;
+
+export const RoleBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: ${theme.colors.white};
+  color: ${theme.colors.black.DEFAULT};
+  font-size: 13px;
+  font-weight: 700;
+`;
+
+export const ShareLinkCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+  padding: 20px;
+  border: 1px solid ${theme.colors.gray.border};
+  border-radius: 20px;
+  background: ${theme.colors.white};
+`;
+
+export const ShareLinkButton = styled.button`
+  display: block;
+  width: 100%;
+  padding: 14px 16px;
+  border: 0;
+  border-radius: 14px;
+  background: ${theme.colors.gray[20]};
+  color: ${theme.colors.black.DEFAULT};
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+`;
+
+export const LinkStatus = styled.p`
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: ${theme.colors.gray[20]};
+  color: ${theme.colors.gray.dark.DEFAULT};
+  font-size: 14px;
+  line-height: 1.45;
+`;
+
+export const CopyStatus = styled.p`
+  margin: 0;
+  color: ${theme.colors.primary};
+  font-size: 13px;
+  font-weight: 700;
+`;
+
+export const LogoutButton = styled(BaseButton).attrs({
+  $fullWidth: true,
+  $height: '52px',
+  $radius: '16px',
+})`
+  margin-top: 20px;
+  background: ${theme.colors.black.DEFAULT};
+  color: ${theme.colors.white};
+`;


### PR DESCRIPTION
## Summary
- Rebuild the mypage content on develop so users can see their logged-in account information.
- Show the owner-only profile share link as `https://snapbook.store/s/{slugOrPublicCode}`.
- Copy the share link to the clipboard on click instead of opening it directly, with success/failure feedback.

## Why
Owners need a stable profile link they can share from their own mypage. Without this, they have to retrieve or infer the store identifier elsewhere, which makes sharing the public SnapBook entry inconvenient and error-prone.

## Tests
- `npm run build`

## Risks
- Clipboard copy depends on browser clipboard permissions and secure context support. The UI shows a failure message if copying is blocked.
- This PR is based on `develop`, where `Mypage.jsx` was still minimal, so it adds the mypage card layout and styles needed to expose the link.